### PR TITLE
Include raw archive in releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,7 @@ jobs:
     name: Build and Release
     needs: lint-and-test
     runs-on: ubuntu-latest
-    # TODO: Revert it (mocked for testing)
-    # if: startswith(github.ref, 'refs/tags/v') # For v* tags
+    if: startswith(github.ref, 'refs/tags/v') # For v* tags
     permissions:
       contents: write
     steps:
@@ -113,12 +112,8 @@ jobs:
         run: node ./scripts/pack-crx.cjs
 
       - name: Release extension
-        run: ls -al raindrop-sync-for-chrome.*
-
-      # TODO: Revert it (mocked for testing)
-      # - name: Release extension
-      #   uses: softprops/action-gh-release@v1
-      #   with:
-      #     files: |
-      #       raindrop-sync-for-chrome.zip
-      #       raindrop-sync-for-chrome.crx
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            raindrop-sync-for-chrome.zip
+            raindrop-sync-for-chrome.crx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,10 @@ jobs:
           files: coverage/clover.xml
           flags: unit
 
-      - name: Build extension
-        run: pnpm run build
-
       - name: Run end-to-end tests
-        run: pnpm run e2e
+        run: |
+          pnpm run build
+          pnpm run e2e
 
   build-and-release:
     name: Build and Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Install PNPM deps
         run: pnpm install
 
+      - name: Build extension
+        run: pnpm run build
+
       - name: Create an archive
         run: zip -r raindrop-sync-for-chrome.zip dist
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,7 @@ on:
       - '**.md'
   workflow_dispatch:
 
-permissions:
-  contents: write
+permissions: read-all
 
 jobs:
   lint-and-test:
@@ -76,31 +75,43 @@ jobs:
       - name: Run end-to-end tests
         run: pnpm run e2e
 
+  build-and-release:
+    name: Build and Release
+    needs: lint-and-test
+    runs-on: ubuntu-latest
+    if: startswith(github.ref, 'refs/tags/v') # For v* tags
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up PNPM
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - name: Install PNPM deps
+        run: pnpm install
+
+      - name: Create an archive
+        run: zip -r raindrop-sync-for-chrome.zip dist
+
       # NOTE: `CRX_PRIVATE_KEY` secret may differ from environments for security reason; e.g. Dependabot PR
       - name: Pack extension
         env:
           CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
         run: node ./scripts/pack-crx.cjs
 
-      - name: Upload extension as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: crx
-          path: raindrop-sync-for-chrome.crx
-          if-no-files-found: error
-
-  release:
-    name: Release
-    needs: lint-and-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download CRX artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: crx
-
       - name: Release extension
         uses: softprops/action-gh-release@v1
-        if: startswith(github.ref, 'refs/tags/v') # For v* tags
         with:
-          files: raindrop-sync-for-chrome.crx
+          files: |
+            raindrop-sync-for-chrome.zip
+            raindrop-sync-for-chrome.crx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,8 @@ jobs:
     name: Build and Release
     needs: lint-and-test
     runs-on: ubuntu-latest
-    if: startswith(github.ref, 'refs/tags/v') # For v* tags
+    # TODO: Revert it (mocked for testing)
+    # if: startswith(github.ref, 'refs/tags/v') # For v* tags
     permissions:
       contents: write
     steps:
@@ -110,8 +111,12 @@ jobs:
         run: node ./scripts/pack-crx.cjs
 
       - name: Release extension
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            raindrop-sync-for-chrome.zip
-            raindrop-sync-for-chrome.crx
+        run: ls -al raindrop-sync-for-chrome.*
+
+      # TODO: Revert it (mocked for testing)
+      # - name: Release extension
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     files: |
+      #       raindrop-sync-for-chrome.zip
+      #       raindrop-sync-for-chrome.crx


### PR DESCRIPTION
Chrome browser seems doesn't allow installing `.crx` files source other than Chrome Web Store.

To allow installing CRX locally using `Load Unpacked`, include extension archive to release.