### PR TITLE
Show notifications on registration failure

### DIFF
--- a/.devcontainer/docker-compose.devcontainer.yaml
+++ b/.devcontainer/docker-compose.devcontainer.yaml
@@ -12,6 +12,7 @@ services:
       disable: true
     cap_add:
       - SYS_ADMIN
+    shm_size: 2gb
 
   novnc:
     image: theasp/novnc:latest

--- a/.devcontainer/docker-compose.devcontainer.yaml
+++ b/.devcontainer/docker-compose.devcontainer.yaml
@@ -7,7 +7,7 @@ services:
     volumes:
       - ..:/workspace
     environment:
-      DISPLAY: novnc:0.0
+      DISPLAY: ${DISPLAY:-novnc:0.0}
     healthcheck:
       disable: true
     cap_add:

--- a/src/components/Config.svelte
+++ b/src/components/Config.svelte
@@ -5,7 +5,7 @@
 	import { get } from 'svelte/store';
 	import Eye from '~/components/Eye.svelte';
 	import { launchWebAuthFlow as _launchWebAuthFlow } from '~/lib/raindrop/auth';
-	import { accessToken, clientID, clientSecret, refreshToken } from '~/lib/settings';
+	import { accessToken, clientID, clientSecret, notifications, refreshToken } from '~/lib/settings';
 
 	let showClientID = false;
 	let showClientSecret = false;
@@ -23,6 +23,10 @@
 		} catch (err) {
 			// TODO: Show error message as modal or toast
 			console.error('Failed to authorize app:', err);
+			$notifications[$notifications.length] = {
+				type: 'error',
+				message: String(err)
+			};
 		}
 	};
 </script>

--- a/src/components/Config.svelte
+++ b/src/components/Config.svelte
@@ -80,7 +80,6 @@
 					classDiv="w-full mr-2"
 					id="access-token"
 					type={showAccessToken ? 'text' : 'password'}
-					disabled
 					bind:value={$accessToken}
 				>
 					Access Token

--- a/src/components/Config.svelte
+++ b/src/components/Config.svelte
@@ -4,8 +4,9 @@
 	import P from 'flowbite-svelte/P.svelte';
 	import { get } from 'svelte/store';
 	import Eye from '~/components/Eye.svelte';
+	import { putMessage } from '~/lib/messages';
 	import { launchWebAuthFlow as _launchWebAuthFlow } from '~/lib/raindrop/auth';
-	import { accessToken, clientID, clientSecret, notifications, refreshToken } from '~/lib/settings';
+	import { accessToken, clientID, clientSecret, refreshToken } from '~/lib/settings';
 
 	let showClientID = false;
 	let showClientSecret = false;
@@ -20,13 +21,10 @@
 			});
 			accessToken.set(result.accessToken);
 			refreshToken.set(result.refreshToken);
+			putMessage({ type: 'success', message: 'Successfully authorized app.' });
 		} catch (err) {
-			// TODO: Show error message as modal or toast
 			console.error('Failed to authorize app:', err);
-			$notifications[$notifications.length] = {
-				type: 'error',
-				message: String(err)
-			};
+			putMessage({ type: 'error', message: String(err) });
 		}
 	};
 </script>

--- a/src/components/Config.test.ts
+++ b/src/components/Config.test.ts
@@ -71,7 +71,7 @@ describe('access token', () => {
 		const { getByTestId } = render(Config);
 		const input = getByTestId('access-token/input') as HTMLInputElement;
 		expect(input).toBeTruthy();
-		expect(input.getAttributeNames()).toContain('disabled');
+		expect(input.getAttributeNames()).not.toContain('disabled');
 	});
 
 	it('is masked by default and able to toggle it', async () => {

--- a/src/components/Message.svelte
+++ b/src/components/Message.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import { Toast } from 'flowbite-svelte';
+	import {
+		CheckCircleSolid,
+		CloseCircleSolid,
+		ExclamationCircleSolid
+	} from 'flowbite-svelte-icons';
+	import type { ComponentType } from 'svelte';
+	import { dismissMessage, type Message } from '~/lib/messages';
+
+	const messageMapping: {
+		[type: string]: { icon: ComponentType; color: 'blue' | 'green' | 'red' };
+	} = {
+		success: {
+			icon: CheckCircleSolid,
+			color: 'green'
+		},
+		info: {
+			icon: ExclamationCircleSolid,
+			color: 'blue'
+		},
+		error: {
+			icon: CloseCircleSolid,
+			color: 'red'
+		}
+	};
+
+	export let message: Message;
+</script>
+
+{#if message}
+	{@const color = messageMapping[message.type].color}
+	{@const icon = messageMapping[message.type].icon}
+	<div {...$$restProps}>
+		<Toast {color} on:close={() => dismissMessage(message.id)}>
+			<svelte:fragment slot="icon">
+				<svelte:component this={icon} class="h-5 w-5" />
+			</svelte:fragment>
+			{message.message}
+		</Toast>
+	</div>
+{/if}

--- a/src/components/Message.test.ts
+++ b/src/components/Message.test.ts
@@ -1,0 +1,9 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/svelte';
+import { expect, it } from 'vitest';
+import Message from './Message.svelte';
+
+it('renders OK', () => {
+	const { container } = render(Message);
+	expect(container).toBeTruthy();
+});

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -1,0 +1,48 @@
+import { writable } from 'svelte/store';
+
+export type Message = {
+	id?: string;
+	type: 'success' | 'info' | 'error';
+	message: string;
+};
+
+export type MessageBox = {
+	[id: string]: Message;
+};
+
+export const messageBox = writable<MessageBox>({});
+
+/**
+ * Put message to message box.
+ * @param message Message to put. If `.id` is not set, random generated ID will be used.
+ * @returns ID of message.
+ */
+export function putMessage(message: Message): string {
+	const id = message.id ?? Math.random().toString(36).substring(2);
+	messageBox.update((box) => {
+		box[id] = { id, ...message };
+		return box;
+	});
+	return id;
+}
+
+/**
+ * Dismiss message with ID.
+ * @param id ID of message.
+ */
+export function dismissMessage(id?: string) {
+	if (!id) return;
+
+	messageBox.update((box) => {
+		delete box[id];
+		return box;
+	});
+}
+
+/* c8 ignore start */
+if (import.meta.vitest) {
+	const { describe } = import.meta.vitest;
+
+	describe.todo('To Do');
+}
+/* c8 ignore stop */

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,4 +1,3 @@
-import { writable } from 'svelte/store';
 import { persisted } from './stores';
 
 const options = {
@@ -18,12 +17,6 @@ export const refreshToken = await persisted('refreshToken', '', options);
  * - Hints from resource servers, such as `$.user.lastAction`, `$.user.lastVisit` from user info data
  */
 export const lastTouch = await persisted('lastTouch', null, options);
-
-type Noti = {
-	type: 'info' | 'success' | 'warning' | 'error';
-	message: string;
-};
-export const notifications = writable<Noti[]>([]);
 
 /* c8 ignore start */
 if (import.meta.vitest) {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,3 +1,4 @@
+import { writable } from 'svelte/store';
 import { persisted } from './stores';
 
 const options = {
@@ -17,6 +18,12 @@ export const refreshToken = await persisted('refreshToken', '', options);
  * - Hints from resource servers, such as `$.user.lastAction`, `$.user.lastVisit` from user info data
  */
 export const lastTouch = await persisted('lastTouch', null, options);
+
+type Noti = {
+	type: 'info' | 'success' | 'warning' | 'error';
+	message: string;
+};
+export const notifications = writable<Noti[]>([]);
 
 /* c8 ignore start */
 if (import.meta.vitest) {

--- a/src/pages/options/Page.svelte
+++ b/src/pages/options/Page.svelte
@@ -16,28 +16,28 @@
 	<Tabs style="underline">
 		<TabItem open>
 			<div slot="title" class="flex items-center gap-2">
-				<BookmarkOutline size="sm" />
+				<BookmarkOutline size="sm" class="outline-none" />
 				Bookmarks
 			</div>
 			<Bookmarks />
 		</TabItem>
 		<TabItem>
 			<div slot="title" class="flex items-center gap-2">
-				<SearchOutline size="sm" />
+				<SearchOutline size="sm" class="outline-none" />
 				Try It
 			</div>
 			<TryIt />
 		</TabItem>
 		<TabItem>
 			<div slot="title" class="flex items-center gap-2">
-				<UserSettingsOutline size="sm" />
+				<UserSettingsOutline size="sm" class="outline-none" />
 				Settings
 			</div>
 			<Config />
 		</TabItem>
 		<TabItem>
 			<div slot="title" class="flex items-center gap-2">
-				<QuestionCircleOutline size="sm" />
+				<QuestionCircleOutline size="sm" class="outline-none" />
 				About
 			</div>
 			<About />

--- a/src/pages/options/Page.svelte
+++ b/src/pages/options/Page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { Toast } from 'flowbite-svelte';
+	import { ExclamationCircleSolid } from 'flowbite-svelte-icons';
 	import BookmarkOutline from 'flowbite-svelte-icons/BookmarkOutline.svelte';
 	import QuestionCircleOutline from 'flowbite-svelte-icons/QuestionCircleOutline.svelte';
 	import SearchOutline from 'flowbite-svelte-icons/SearchOutline.svelte';
@@ -10,6 +12,7 @@
 	import Bookmarks from '~/components/Bookmarks.svelte';
 	import Config from '~/components/Config.svelte';
 	import TryIt from '~/components/TryIt.svelte';
+	import { notifications } from '~/lib/settings';
 </script>
 
 <main class="mx-1 mt-4 self-center">
@@ -43,6 +46,20 @@
 			<About />
 		</TabItem>
 	</Tabs>
+
+	<!-- TODO: Currently implemented for error event only, component-ize for more types -->
+	<!-- TODO: Notification should be removed from array when dismissed -->
+	<div class="absolute right-8 top-8 space-y-4">
+		{#each $notifications as noti}
+			<Toast color="red">
+				<svelte:fragment slot="icon">
+					<ExclamationCircleSolid class="h-5 w-5" />
+					<span class="sr-only">Warning icon</span>
+				</svelte:fragment>
+				{noti.message}
+			</Toast>
+		{/each}
+	</div>
 </main>
 
 <style lang="postcss">

--- a/src/pages/options/Page.svelte
+++ b/src/pages/options/Page.svelte
@@ -16,28 +16,28 @@
 	<Tabs style="underline">
 		<TabItem open>
 			<div slot="title" class="flex items-center gap-2">
-				<BookmarkOutline size="sm" class="outline-none" />
+				<BookmarkOutline size="sm" />
 				Bookmarks
 			</div>
 			<Bookmarks />
 		</TabItem>
 		<TabItem>
 			<div slot="title" class="flex items-center gap-2">
-				<SearchOutline size="sm" class="outline-none" />
+				<SearchOutline size="sm" />
 				Try It
 			</div>
 			<TryIt />
 		</TabItem>
 		<TabItem>
 			<div slot="title" class="flex items-center gap-2">
-				<UserSettingsOutline size="sm" class="outline-none" />
+				<UserSettingsOutline size="sm" />
 				Settings
 			</div>
 			<Config />
 		</TabItem>
 		<TabItem>
 			<div slot="title" class="flex items-center gap-2">
-				<QuestionCircleOutline size="sm" class="outline-none" />
+				<QuestionCircleOutline size="sm" />
 				About
 			</div>
 			<About />

--- a/src/pages/options/Page.svelte
+++ b/src/pages/options/Page.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { Toast } from 'flowbite-svelte';
-	import { ExclamationCircleSolid } from 'flowbite-svelte-icons';
 	import BookmarkOutline from 'flowbite-svelte-icons/BookmarkOutline.svelte';
 	import QuestionCircleOutline from 'flowbite-svelte-icons/QuestionCircleOutline.svelte';
 	import SearchOutline from 'flowbite-svelte-icons/SearchOutline.svelte';
@@ -11,8 +9,9 @@
 	import About from '~/components/About.svelte';
 	import Bookmarks from '~/components/Bookmarks.svelte';
 	import Config from '~/components/Config.svelte';
+	import Message from '~/components/Message.svelte';
 	import TryIt from '~/components/TryIt.svelte';
-	import { notifications } from '~/lib/settings';
+	import { messageBox } from '~/lib/messages';
 </script>
 
 <main class="mx-1 mt-4 self-center">
@@ -47,17 +46,10 @@
 		</TabItem>
 	</Tabs>
 
-	<!-- TODO: Currently implemented for error event only, component-ize for more types -->
-	<!-- TODO: Notification should be removed from array when dismissed -->
-	<div class="absolute right-8 top-8 space-y-4">
-		{#each $notifications as noti}
-			<Toast color="red">
-				<svelte:fragment slot="icon">
-					<ExclamationCircleSolid class="h-5 w-5" />
-					<span class="sr-only">Warning icon</span>
-				</svelte:fragment>
-				{noti.message}
-			</Toast>
+	<!-- Global message box -->
+	<div class="absolute right-6 top-6 space-y-2">
+		{#each Object.entries($messageBox) as [id, message] (id)}
+			<Message {message} />
 		{/each}
 	</div>
 </main>

--- a/src/pages/options/Page.svelte
+++ b/src/pages/options/Page.svelte
@@ -16,28 +16,28 @@
 	<Tabs style="underline">
 		<TabItem open>
 			<div slot="title" class="flex items-center gap-2">
-				<BookmarkOutline size="sm" />
+				<BookmarkOutline size="sm" class="focus:outline-none" />
 				Bookmarks
 			</div>
 			<Bookmarks />
 		</TabItem>
 		<TabItem>
 			<div slot="title" class="flex items-center gap-2">
-				<SearchOutline size="sm" />
+				<SearchOutline size="sm" class="focus:outline-none" />
 				Try It
 			</div>
 			<TryIt />
 		</TabItem>
 		<TabItem>
 			<div slot="title" class="flex items-center gap-2">
-				<UserSettingsOutline size="sm" />
+				<UserSettingsOutline size="sm" class="focus:outline-none" />
 				Settings
 			</div>
 			<Config />
 		</TabItem>
 		<TabItem>
 			<div slot="title" class="flex items-center gap-2">
-				<QuestionCircleOutline size="sm" />
+				<QuestionCircleOutline size="sm" class="focus:outline-none" />
 				About
 			</div>
 			<About />


### PR DESCRIPTION
Display a toast notification if the OAuth application registration is unsuccessful.

Additionally, implement the following features:

- Enable users to manually input an access token, allowing the use of a test token and eliminating the necessity for OAuth app registration.
- Eliminate the unattractive focus outline around the menu icon when it is clicked.

Resolves #28 and fixes #38.