### PR TITLE
Use GitHub OIDC for Codecov actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -53,17 +56,18 @@ jobs:
         run: yarn run test
 
       - name: Upload test results to codecov
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           fail_ci_if_error: false
+          report_type: test_results
           files: junit.xml
           flags: unit
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           fail_ci_if_error: false
           files: coverage/clover.xml
           flags: unit
@@ -72,6 +76,9 @@ jobs:
     name: E2E Test
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -94,16 +101,15 @@ jobs:
             ${{ runner.os }}-puppeteer-
 
       - name: Run end-to-end tests
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           yarn run build
           yarn run e2e
 
       - name: Upload test results to codecov
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           fail_ci_if_error: false
+          report_type: test_results
           files: junit.xml
           flags: e2e

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,9 +11,11 @@ export const viteConfig = {
 		svelte(),
 		crx({ manifest }),
 		codecovVitePlugin({
-			enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+			enableBundleAnalysis: true,
 			bundleName: 'raindrop-sync-chrome',
-			uploadToken: process.env.CODECOV_TOKEN
+			oidc: {
+				useGitHubOIDC: true
+			}
 		})
 	],
 	resolve: {


### PR DESCRIPTION
Replace Codecov upload token with GitHub OIDC.