### PR TITLE
Fix browser not starting with extension loaded

### DIFF
--- a/.devcontainer.example/Dockerfile
+++ b/.devcontainer.example/Dockerfile
@@ -5,7 +5,7 @@ USER root:root
 SHELL ["/bin/bash", "-c"]
 
 # Install core tools
-RUN apt-get update && apt-get install --no-install-recommends -y \
+RUN apt-get update && apt-get install --no-install-recommends --yes \
     curl \
     fonts-noto \
     git \
@@ -13,17 +13,4 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     make \
     python3-pip \
     xauth \
-    xvfb \
-    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-    && rm -rf /var/lib/apt/lists/*
-
-# Add Google APT repository
-RUN ARCH=$(dpkg --print-architecture) \
-    && curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor --output /usr/share/keyrings/google-chrome.gpg \
-    && echo "deb [arch=${ARCH} signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/chrome.list
-
-# Install core tools
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    google-chrome-stable \
-    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-    && rm -rf /var/lib/apt/lists/*
+    xvfb

--- a/.devcontainer.example/devcontainer-lock.json
+++ b/.devcontainer.example/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+	"features": {
+		"ghcr.io/devcontainers-extra/features/pre-commit:2": {
+			"version": "2.0.18",
+			"resolved": "ghcr.io/devcontainers-extra/features/pre-commit@sha256:6e0bb2ce80caca1d94f44dab5d0653d88a1c00984e590adb7c6bce012d0ade6e",
+			"integrity": "sha256:6e0bb2ce80caca1d94f44dab5d0653d88a1c00984e590adb7c6bce012d0ade6e"
+		},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"version": "2.17.0",
+			"resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c",
+			"integrity": "sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c"
+		}
+	}
+}

--- a/.devcontainer.example/docker-compose.devcontainer.yaml
+++ b/.devcontainer.example/docker-compose.devcontainer.yaml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: ./Dockerfile
     volumes:
-      - google-chrome:/home/node/.config/google-chrome/Default
+      - google-chrome:/home/node/.config/google-chrome-for-testing
     environment:
       CONTAINER: 1
       DISPLAY: ${DISPLAY:-novnc:0.0}

--- a/.devcontainer.example/onCreateCommand.sh
+++ b/.devcontainer.example/onCreateCommand.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-sudo chown --recursive "$(id --user):$(id --group)" ~/.config/google-chrome
+sudo chown --recursive "$(id --user):$(id --group)" ~/.config/google-chrome-for-testing

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,14 +17,14 @@ repos:
         name: prettier
         language: system
         types_or: [javascript, ts, svelte, json, yaml]
-        entry: yarn run prettier
+        entry: yarn exec -- prettier
         args: [--write]
 
       - id: eslint
         name: eslint
         language: system
         types_or: [javascript, ts, svelte]
-        entry: yarn run eslint
+        entry: yarn exec -- eslint
         args: [--fix]
 
       - id: typescript
@@ -32,7 +32,7 @@ repos:
         language: system
         types_or: [javascript, ts, svelte]
         pass_filenames: false
-        entry: yarn run tsc
+        entry: yarn exec -- tsc
         args: [--noEmit]
 
       - id: vitest

--- a/.vscode.example/settings.json
+++ b/.vscode.example/settings.json
@@ -1,8 +1,17 @@
 {
-	"editor.defaultFormatter": "esbenp.prettier-vscode",
-	"[json][jsonc][yaml][dockercompose]": {
+	"[dockercompose]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	},
+	"[json]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"[jsonc]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"[yaml]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"editor.defaultFormatter": "esbenp.prettier-vscode",
 	"files.associations": {
 		"**/*.css": "tailwindcss"
 	},

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help: Makefile  ## Show this help message
 # =============================================================================
 install:  ## Install deps and tools
 	yarn install
-	yarn run playwright install --with-deps
+	yarn exec -- playwright install --with-deps chromium
 .PHONY: install
 
 init:  ## Initialize the project workspace
@@ -33,21 +33,23 @@ update:  ## Update deps and tools
 
 # Note, --user-data-dir flag is required for debugger to work properly
 # https://stackoverflow.com/questions/56326924/debugging-a-chrome-instance-with-remote-debugging-port-flag
-browser:  ## Launch browser with extensions loaded
-	google-chrome \
+browser:  ## Launch Chrome for Testing with extension loaded
+	cft_path="$$(node --eval 'const { chromium } = require("playwright"); console.log(chromium.executablePath());')"
+	"$$cft_path" \
 		--no-first-run \
 		--disable-gpu \
-		--load-extension="${PWD}/dist" \
+		--load-extension="$(CURDIR)/dist" \
+		--disable-extensions-except="$(CURDIR)/dist" \
 		--no-sandbox \
 		--remote-debugging-port=9222 \
-		--user-data-dir=./chrome-dev-profile \
+		--user-data-dir="$(CURDIR)/chrome-dev-profile" \
 		--enable-logging \
 		--v=1 \
-		--log-file=./chrome.log
+		--log-file="$(CURDIR)/chrome.log"
 .PHONY: browser
 
 run:  ## Run browser with development server
-	yarn run concurrently \
+	yarn exec -- concurrently \
 		--kill-others \
 		--kill-signal SIGKILL \
 		--raw \


### PR DESCRIPTION
Fixes Chrome browser does start with extension loaded. `--load-extension` argument is removed in Chrome 137 (https://developer.chrome.com/blog/extension-news-june-2025).

Instead, use Chrome for Testing browser installed by Playwright (chromium channel) to launch browser with extension loaded.